### PR TITLE
bug fix in looseValue Caixa aberto

### DIFF
--- a/src/components/MarketCard/schema.ts
+++ b/src/components/MarketCard/schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 const schema = z.object({
-  looseValue: z.number().min(0),
+  looseValue: z.coerce.number().min(0),
 });
 
 export type SchemaData = z.infer<typeof schema>;


### PR DESCRIPTION
Adicionando `coerce` no atributo do schema de validação de dados do _form_.

```typescript
const schema = z.object({
  looseValue: z.coerce.number().min(0),
});
```